### PR TITLE
Fix #12: Add @component JSDoc tag to App component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import './App.css';
 
 /**
  * Main application component
+ * @component
  *
  * Features:
  * - Territory count configuration


### PR DESCRIPTION
## Summary
Adds standard JSDoc `@component` annotation to the main App component for improved documentation.

## Changes
- Added `@component` JSDoc tag to App function documentation

## Benefits
- Better IDE integration and autocomplete
- Improved type documentation generation
- Standard JSDoc annotation for React components

## Testing
- ✅ Documentation-only change, no functional impact
- ✅ TypeScript compilation passes

Closes #12